### PR TITLE
docs(guides): clarify webhook event behavior for withdrawals and add examples

### DIFF
--- a/v2/guides/webhooks-callbacks/set-up-endpoint.mdx
+++ b/v2/guides/webhooks-callbacks/set-up-endpoint.mdx
@@ -81,6 +81,9 @@ Properly responding to webhook events and callback messages is crucial for ensur
 When your webhook endpoint receives a webhook event, it should respond with a status code of `200` or `201` to indicate that the event has been successfully received and processed. Once this response is sent, the WaaS service will stop retrying to send the event and the event status will become `Delivered` on Cobo Portal.
 
 The default timeout for each webhook event is 2 seconds. If the webhook endpoint does not respond or responds with a status code other than `200` or `201`, the WaaS service will continue to retry sending the event. If the number of retry attempts reaches 10 , the WaaS service will stop sending the event and the event status will become `Failed`· You can resend the event by clicking **Retry** on **Cobo Portal** > **Developer** > **WaaS 2.0** > **Webhook Events**.
+{/* TODO: Add retry interval schedule (exponential backoff details) once confirmed by backend team. */}
+
+<Info>If you do not receive an expected webhook event, check the event status on **Cobo Portal** > **Developer** > **Webhook Events** to determine whether the event was generated and its delivery status.</Info>
 
 Cobo does not guarantee that events will be delivered in the order they are generated. For example, creating a transfer will generate the following events:
 
@@ -95,6 +98,7 @@ Your endpoint should not assume that events will arrive in this sequence and mus
 When your callback endpoint receives a callback message, it should respond with a status code of `200` or `201` and a response body of `ok` or `deny` to indicate transaction approval or rejection. Once this response is sent, the WaaS service will stop retrying to send the message and the callback message status will become `Delivered`on Cobo Portal.
 
 If the callback endpoint does not respond, responds with a status code other than `200` or `201`,  or the response body does not contain `ok` or `deny`, the WaaS service will continue to retry sending the message.  If the number of retry attempts reaches 30, the WaaS service will stop sending the message and the callback message status will become `Failed`. You can resend the message by using the [Retry callback message](/v2/api-references/developers/retry-callback-message) operation.
+{/* TODO: Add retry interval schedule (exponential backoff details) once confirmed by backend team. */}
 
 ### Common delivery failures
 

--- a/v2/guides/webhooks-callbacks/webhook-event-type.mdx
+++ b/v2/guides/webhooks-callbacks/webhook-event-type.mdx
@@ -33,12 +33,13 @@ For payment webhook events, please refer to [Order Status and Events](/v2/paymen
     <tr>
       <td><code>wallets.transaction.created</code></td>
       <td><code>Transaction</code></td>
-      <td>A transaction has been detected on the blockchain, generating a transaction record. This event does not indicate that the transaction was successful.</td>
+      <td>A new transaction record has been created. For deposits, this occurs when the transaction is detected on the blockchain. For withdrawals and contract calls initiated via the API, this occurs when the transaction request is submitted. This event does not indicate that the transaction was successful.</td>
     </tr>
     <tr>
       <td><code>wallets.transaction.updated</code></td>
       <td><code>Transaction</code></td>
-      <td>There are changes to a transaction's status or confirmation numbers.<Note>The <code>wallets.transaction.updated</code> event covers the entire lifecycle of a transaction, including creation, completion, and failure. If you want to track every status change, you need only subscribe to this event.</Note></td>
+      {/* SUB_STATUS_TRIGGER: Inferred from dedupe-key analysis. Verify with backend team. */}
+      <td>There are changes to a transaction's top-level status (for example, from Submitted to PendingScreening) or confirmation count. Sub-status changes within the same top-level status may not trigger a separate event.<Note>The <code>wallets.transaction.updated</code> event covers the entire lifecycle of a transaction, including creation, completion, and failure. If you want to track every status change, you need only subscribe to this event.</Note></td>
     </tr>
     <tr>
       <td><code>wallets.transaction.succeeded</code></td>
@@ -62,6 +63,25 @@ For payment webhook events, please refer to [Order Status and Events](/v2/paymen
     </tr>
   </tbody>
 </table>
+
+{/* STATUS_MATRIX: Inferred from OpenAPI enum and set-up-endpoint.mdx. Verify with backend team before publishing. */}
+#### Withdrawal status and webhook event mapping
+
+The following table shows which webhook events are typically triggered at each withdrawal status. For a full list of transaction statuses and sub-statuses, refer to [Transaction statuses and sub-statuses](/v2/guides/transactions/status).
+
+<Warning>The exact mapping may vary depending on your wallet type and configuration. Subscribe to `wallets.transaction.updated` to track the full withdrawal lifecycle.</Warning>
+
+| Status | `wallets.transaction.created` | `wallets.transaction.updated` | `wallets.transaction.succeeded` | `wallets.transaction.failed` |
+|---|---|---|---|---|
+| Submitted | Yes | Yes | | |
+| PendingScreening | | Yes | | |
+| PendingAuthorization | | Yes | | |
+| PendingSignature | | Yes | | |
+| Broadcasting | | Yes | | |
+| Confirming | | Yes | | |
+| Completed | | Yes | Yes | |
+| Failed | | Yes | | Yes |
+| Rejected | | Yes | | Yes |
 
 ### Fee Station events
 
@@ -256,6 +276,78 @@ For payment webhook events, please refer to [Order Status and Events](/v2/paymen
 For a complete introduction of the webhook event data and its data structure, refer to the [data](/v2/api-references/developers--webhooks/retrieve-event-information#response-data) property in the response of the Retrieve event information operation or the [data.data](/v2/api-references/developers--webhooks/list-all-webhook-events#response-data-data) property in the response of the List all webhook event operation. 
 
 <img src="/v2/images/guides/webhook_data_structure.png" class="screenshot_full_screen" alt="Screenshot of the data property" />
+
+<Accordion title="Example: wallets.transaction.created event for a withdrawal">
+
+The following is a simplified example of a `wallets.transaction.created` webhook event payload for a withdrawal transaction. For the complete data structure, refer to the [Transaction schema](/v2/api-references/developers--webhooks/retrieve-event-information#response-data).
+
+```json
+{
+  "event_id": "evt_a1b2c3d4e5f6",
+  "event_type": "wallets.transaction.created",
+  "data": {
+    "data_type": "Transaction",
+    "transaction_id": "aff0e1cb-15b2-4e1f-9b9d-a9133715986f",
+    "cobo_id": "20231213122855000000000000000000",
+    "request_id": "760a1955-e212-4dfb-a8d0-e66312a1a051",
+    "wallet_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    "type": "Withdraw",
+    "status": "Submitted",
+    "sub_status": null,
+    "chain_id": "ETH",
+    "token_id": "ETH_USDT",
+    "source": {
+      "source_type": "Org-Controlled",
+      "wallet_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+      "address": "0x1234...abcd"
+    },
+    "destination": {
+      "destination_type": "Address",
+      "address": "0x5678...efgh"
+    },
+    "created_timestamp": 1702468135000,
+    "updated_timestamp": 1702468135000
+  }
+}
+```
+
+</Accordion>
+
+<Accordion title="Example: wallets.transaction.updated event with Confirming status">
+
+The following is a simplified example of a `wallets.transaction.updated` webhook event payload when a withdrawal reaches the `Confirming` status.
+
+```json
+{
+  "event_id": "evt_f6e5d4c3b2a1",
+  "event_type": "wallets.transaction.updated",
+  "data": {
+    "data_type": "Transaction",
+    "transaction_id": "aff0e1cb-15b2-4e1f-9b9d-a9133715986f",
+    "cobo_id": "20231213122855000000000000000000",
+    "request_id": "760a1955-e212-4dfb-a8d0-e66312a1a051",
+    "wallet_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    "type": "Withdraw",
+    "status": "Confirming",
+    "sub_status": "PendingBlockConfirmations",
+    "chain_id": "ETH",
+    "token_id": "ETH_USDT",
+    "source": {
+      "source_type": "Org-Controlled",
+      "wallet_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+      "address": "0x1234...abcd"
+    },
+    "destination": {
+      "destination_type": "Address",
+      "address": "0x5678...efgh"
+    },
+    "created_timestamp": 1702468135000,
+    "updated_timestamp": 1702468200000
+  }
+}
+```
+
+</Accordion>
 
 Switch between the event data types to view the data structure of each event data type.
 

--- a/v2_cn/guides/webhooks-callbacks/set-up-endpoint.mdx
+++ b/v2_cn/guides/webhooks-callbacks/set-up-endpoint.mdx
@@ -81,6 +81,9 @@ Webhook 事件和 Callback 消息对于确保 WaaS 服务与您的 App 之间的
 当您的 Webhook Endpoint 收到 Webhook 事件时，它应该响应状态码 `200` 或 `201` 以指示事件已成功接收和处理。一旦发送此响应，WaaS 服务将停止重试发送事件，事件状态将变为**已送达**。
 
 默认情况下，每个 Webhook 事件的超时时间为 2 秒。如果 Webhook Endpoint 没有响应或响应状态码不是 `200` 或 `201`，WaaS 服务将继续重试发送事件。如果重试次数达到 10 次，WaaS 服务将停止发送事件，事件状态将变为**发送失败**。您可以通过单击 Cobo Portal > 开发者 > WaaS 2.0 > Webhook 事件上的**重新发送**来重新发送事件。
+{/* TODO: Add retry interval schedule (exponential backoff details) once confirmed by backend team. */}
+
+<Info>如果未收到预期的 Webhook 事件，请在 **Cobo Portal** > **Developer** > **Webhook Events** 中检查事件状态，确认事件是否已生成及其投递状态。</Info>
 
 Cobo 不保证事件将按生成顺序交付。例如，创建转账将生成以下事件：
 
@@ -95,6 +98,7 @@ Cobo 不保证事件将按生成顺序交付。例如，创建转账将生成以
 当您的 Callback Endpoint 收到 Callback 消息时，它应该响应状态码 `200` 或 `201` 和响应包体 `ok` 或 `deny` 以指示交易批准或拒绝。一旦发送此响应，WaaS 服务将停止重试发送消息，Callback 消息状态将变为**已送达**。
 
 如果 Callback Endpoint 没有响应，响应状态码不是 `200` 或 `201`，或响应包体不包含 `ok` 或 `deny`，WaaS 服务将继续重试发送消息。如果重试次数达到 30 次，WaaS 服务将停止发送消息，Callback 消息状态将变为**发送失败**。您可以使用 [Retry callback message](/v2/api-references/developers/retry-callback-message) 来重新发送消息。
+{/* TODO: Add retry interval schedule (exponential backoff details) once confirmed by backend team. */}
 
 ### 常见投递失败原因
 

--- a/v2_cn/guides/webhooks-callbacks/webhook-event-type.mdx
+++ b/v2_cn/guides/webhooks-callbacks/webhook-event-type.mdx
@@ -34,12 +34,13 @@ import WaasSkillReminder from '/snippets/waas_skill_reminder_cn.mdx';
     <tr>
       <td><code>wallets.transaction.created</code></td>
       <td><code>Transaction</code></td>
-      <td>在区块链上检测到交易并生成记录。此事件不代表交易已成功。</td>
+      <td>已创建新的交易记录。对于充币，此事件在区块链上检测到交易时触发。对于通过 API 发起的提币和合约调用，此事件在提交交易请求时触发。此事件不代表交易已成功。</td>
     </tr>
     <tr>
       <td><code>wallets.transaction.updated</code></td>
       <td><code>Transaction</code></td>
-      <td>交易的状态或确认数发生变化。<Note>`wallets.transaction.updated` 涵盖交易的整个生命周期，包括创建、完成和失败。如果您想跟踪每个状态变化，订阅此事件即可。</Note></td>
+      {/* SUB_STATUS_TRIGGER: Inferred from dedupe-key analysis. Verify with backend team. */}
+      <td>交易的顶级状态（例如，从 Submitted 变为 PendingScreening）或确认数发生变化。在同一顶级状态下的子状态变更可能不会触发单独的事件。<Note>`wallets.transaction.updated` 涵盖交易的整个生命周期，包括创建、完成和失败。如果您想跟踪每个状态变化，订阅此事件即可。</Note></td>
     </tr>
     <tr>
       <td><code>wallets.transaction.succeeded</code></td>
@@ -64,6 +65,24 @@ import WaasSkillReminder from '/snippets/waas_skill_reminder_cn.mdx';
   </tbody>
 </table>
 
+{/* STATUS_MATRIX: Inferred from OpenAPI enum and set-up-endpoint.mdx. Verify with backend team before publishing. */}
+#### 提币状态与 Webhook 事件对应关系
+
+下表展示了每个提币状态通常会触发哪些 Webhook 事件。有关交易状态和子状态的完整列表，请参阅 [Transaction statuses and sub-statuses](/v2/guides/transactions/status)。
+
+<Warning>具体的事件映射可能因钱包类型和配置而异。订阅 `wallets.transaction.updated` 以跟踪完整的提币生命周期。</Warning>
+
+| Status | `wallets.transaction.created` | `wallets.transaction.updated` | `wallets.transaction.succeeded` | `wallets.transaction.failed` |
+|---|---|---|---|---|
+| Submitted | Yes | Yes | | |
+| PendingScreening | | Yes | | |
+| PendingAuthorization | | Yes | | |
+| PendingSignature | | Yes | | |
+| Broadcasting | | Yes | | |
+| Confirming | | Yes | | |
+| Completed | | Yes | Yes | |
+| Failed | | Yes | | Yes |
+| Rejected | | Yes | | Yes |
 
 ### Fee Station 相关事件
 
@@ -258,6 +277,78 @@ import WaasSkillReminder from '/snippets/waas_skill_reminder_cn.mdx';
 有关 webhook 事件数据和其数据结构的完整介绍，请参阅 Retrieve event information 操作的响应中的 [data](/v2/api-references/developers--webhooks/retrieve-event-information#response-data) 属性或 List all webhook events 操作的响应中的 [data.data](/v2/api-references/developers--webhooks/list-all-webhook-events#response-data-data) 属性。
 
 <img src="/v2/images/guides/webhook_data_structure.png" className="screenshot_full_screen" alt="Webhook 数据结构截图" />
+
+<Accordion title="示例：提币的 wallets.transaction.created 事件">
+
+以下是提币交易的 `wallets.transaction.created` Webhook 事件 payload 简化示例。有关完整数据结构，请参阅 [Transaction schema](/v2/api-references/developers--webhooks/retrieve-event-information#response-data)。
+
+```json
+{
+  "event_id": "evt_a1b2c3d4e5f6",
+  "event_type": "wallets.transaction.created",
+  "data": {
+    "data_type": "Transaction",
+    "transaction_id": "aff0e1cb-15b2-4e1f-9b9d-a9133715986f",
+    "cobo_id": "20231213122855000000000000000000",
+    "request_id": "760a1955-e212-4dfb-a8d0-e66312a1a051",
+    "wallet_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    "type": "Withdraw",
+    "status": "Submitted",
+    "sub_status": null,
+    "chain_id": "ETH",
+    "token_id": "ETH_USDT",
+    "source": {
+      "source_type": "Org-Controlled",
+      "wallet_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+      "address": "0x1234...abcd"
+    },
+    "destination": {
+      "destination_type": "Address",
+      "address": "0x5678...efgh"
+    },
+    "created_timestamp": 1702468135000,
+    "updated_timestamp": 1702468135000
+  }
+}
+```
+
+</Accordion>
+
+<Accordion title="示例：Confirming 状态的 wallets.transaction.updated 事件">
+
+以下是提币到达 `Confirming` 状态时 `wallets.transaction.updated` Webhook 事件 payload 的简化示例。
+
+```json
+{
+  "event_id": "evt_f6e5d4c3b2a1",
+  "event_type": "wallets.transaction.updated",
+  "data": {
+    "data_type": "Transaction",
+    "transaction_id": "aff0e1cb-15b2-4e1f-9b9d-a9133715986f",
+    "cobo_id": "20231213122855000000000000000000",
+    "request_id": "760a1955-e212-4dfb-a8d0-e66312a1a051",
+    "wallet_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    "type": "Withdraw",
+    "status": "Confirming",
+    "sub_status": "PendingBlockConfirmations",
+    "chain_id": "ETH",
+    "token_id": "ETH_USDT",
+    "source": {
+      "source_type": "Org-Controlled",
+      "wallet_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+      "address": "0x1234...abcd"
+    },
+    "destination": {
+      "destination_type": "Address",
+      "address": "0x5678...efgh"
+    },
+    "created_timestamp": 1702468135000,
+    "updated_timestamp": 1702468200000
+  }
+}
+```
+
+</Accordion>
 
 您可以在事件数据类型之间切换来查看每个事件数据类型的数据结构。
 


### PR DESCRIPTION
## Summary

- Rewrites the `wallets.transaction.created` event description to clarify that for withdrawals and contract calls, the event fires at API submission, not on-chain detection (fixes user confusion reported in feedback ticket)
- Adds two expandable example webhook payloads (created + updated events)
- Adds a withdrawal status-to-webhook event mapping matrix table
- Clarifies `wallets.transaction.updated` trigger granularity (top-level status vs sub-status)
- Adds troubleshooting guidance for missing webhook events
- All changes applied to both English and Chinese documentation

## Backend review needed

The following additions are flagged with MDX comments for backend team verification before publishing:
- **Status matrix** (`STATUS_MATRIX` comment): The status-to-event mapping is inferred from the OpenAPI enum and existing docs, not confirmed by backend code
- **Sub-status trigger behavior** (`SUB_STATUS_TRIGGER` comment): The claim that sub-status changes may not trigger separate events needs backend confirmation

## Test plan

- [x] `npx mintlify validate` passes (pre-existing unrelated warning only)
- [ ] Backend team reviews status matrix accuracy
- [ ] Backend team confirms sub-status trigger behavior
- [ ] Visual review of Accordion payloads in Mintlify preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)