### PR TITLE
fix: correct autosweep cancel navigation slug in docs.json (error code 12007 investigation)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -343,7 +343,7 @@
                       "v2/api-references/autosweep/create-auto-sweep-task",
                       "v2/api-references/autosweep/list-auto-sweep-tasks",
                       "v2/api-references/autosweep/get-auto-sweep-task-details",
-                      "v2/api-references/autosweep/cancel-auto-sweep-task-by-id"
+                      "v2/api-references/autosweep/cancel-auto-sweep-task"
                     ]
                   },
                   {


### PR DESCRIPTION
## Summary

Fix a pre-existing broken navigation slug in `docs.json` that caused `mintlify validate` to fail:

- `v2/api-references/autosweep/cancel-auto-sweep-task-by-id` → `v2/api-references/autosweep/cancel-auto-sweep-task`

The referenced page `cancel-auto-sweep-task.mdx` already covers `POST /auto_sweep/tasks/{task_id}/cancel`. No `.mdx` files were created or renamed.

## ⚠️ 待确认事项（与错误码 12007 相关，本次 PR 未包含该变更）

本次工单的核心需求是为 DOGE 提币返回的错误码 **12007** 补充文档，但由于无法从本仓库源码中确认相关内容，**该变更未被纳入本次 PR**，需人工验证后再单独提交：

1. **12007 是否真的对应 UTXO 链 mempool/广播失败？** 工单（DOGE 提币，余额充足但触发 12007）指向 stale-mempool 根因，需 Cobo 后端介入——但未在代码中找到确认。仓库内现有证据（v1 错误码表、`mpc_estimate_fee` 文档）仅支持"余额不足"含义。
2. **12007 是否是一个重载码？** "余额不足"和"广播失败"是否共用同一个码？
3. **与 30012 的关系**：30012 是否也存在同样的重载，还是仅限于余额不足？这影响现有 `12007, 30012` 合并行是否需要拆分。
4. **解决方案**：如果根因是后端问题，解决方案是否完全依赖联系 Cobo Support？还是存在客户端可重试的场景？

确认后需在后端代码（custody/cobo-libs）中定位 12007 常量/处理器，再更新 `snippets/error-codes.mdx` 和 `snippets/error-codes-cn.mdx`。