### PR TITLE
fix: correct autosweep cancel navigation slug in docs.json (wallet name constraints investigation)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -343,7 +343,7 @@
                       "v2/api-references/autosweep/create-auto-sweep-task",
                       "v2/api-references/autosweep/list-auto-sweep-tasks",
                       "v2/api-references/autosweep/get-auto-sweep-task-details",
-                      "v2/api-references/autosweep/cancel-auto-sweep-task-by-id"
+                      "v2/api-references/autosweep/cancel-auto-sweep-task"
                     ]
                   },
                   {


### PR DESCRIPTION
## Summary

Fix a pre-existing broken navigation slug in `docs.json` that caused `mintlify validate` to fail:

- `v2/api-references/autosweep/cancel-auto-sweep-task-by-id` → `v2/api-references/autosweep/cancel-auto-sweep-task`

The referenced page `cancel-auto-sweep-task.mdx` already covers `POST /auto_sweep/tasks/{task_id}/cancel`. No `.mdx` files were created or renamed.

See also: companion api-spec PR for the wallet name constraints change.

## ⚠️ 待确认事项（与钱包名称字符限制相关，本次 PR 未包含该变更）

本次工单的核心需求是为 Create Wallet API 的 `name` 参数补充字符和长度限制说明，但由于无法从本仓库源码中确认具体约束值，**该变更未被纳入本次 PR**，需人工验证后在 `developer-site-waas2` 仓库单独完善（见对应 api-spec PR）：

1. **允许的字符集**：`name` 字段的精确允许字符集是什么？`@` 被拒绝是基于明确白名单/正则，还是其他规则的副作用？
2. **最小和最大长度**：enforced 的 `minLength` / `maxLength` 值是多少？确认后需添加到 schema。
3. **错误码/消息**：无效名称返回的错误码和消息文本是什么（以便在文档中一并说明）？
4. **约束形式**：约束应编码为 OpenAPI `pattern` / `maxLength`（机器可验证），还是仅在 `description` 中以散文说明？
5. **其他补充位置**：`v2/guides/overview/changelog.mdx:50` 和 `v2_cn/guides/overview/changelog.mdx:50` 中的 `cancel-auto-sweep-task-by-id` 内联链接（非导航条目，不影响 validate）也应同步修正，指向 `/v2/api-references/autosweep/cancel-auto-sweep-task`。