### PR TITLE
docs: 完善交易分页 cursor/direction、新增地址校验指南与 KYT 审查状态枚举文档

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -63,6 +63,7 @@
                     ]
                   },
                   "v2/guides/transactions/manage-transactions",
+                  "v2/guides/transactions/validate-addresses",
                   {
                     "group": "Smart contract call samples",
                     "pages": [
@@ -870,6 +871,7 @@
                     ]
                   },
                   "v2_cn/guides/transactions/manage-transactions",
+                  "v2_cn/guides/transactions/validate-addresses",
                   {
                     "group": "智能合约调用示例",
                     "pages": [

--- a/v1/faqs/address-management.mdx
+++ b/v1/faqs/address-management.mdx
@@ -15,5 +15,5 @@ description: "Frequently Asked Questions about Address Management "
 ### How to verify whether a withdraw address is legitimate?
     <Expandable title="Answer">
         <ResponseField >You can use the [GET /v1/custody/is_valid_address/](/v1/api-references/custody-wallet/is_valid_address) endpoint to query whether a withdraw address under a Custodial Wallet is legitimate.
-        For an MPC Wallet, please use the [GET /v1/custody/mpc/is_valid_address/](/v1/api-references/mpc-wallet/mpc_is_valid_address) endpoint instead. If the response returns an zero, it indicates that the address is deemed invalid.</ResponseField>
+        For an MPC Wallet, please use the [GET /v1/custody/mpc/is_valid_address/](/v1/api-references/mpc-wallet/mpc_is_valid_address) endpoint instead. If the response returns an zero, it indicates that the address is deemed invalid. If you are using WaaS 2.0, validate addresses with the [Check address validity](/v2/api-references/wallets/check-address-validity) operation instead. For more information, see [Validate addresses](/v2/guides/transactions/validate-addresses).</ResponseField>
   </Expandable>

--- a/v2/guides/transactions/manage-transactions.mdx
+++ b/v2/guides/transactions/manage-transactions.mdx
@@ -10,6 +10,24 @@ import WaasSkillReminder from '/snippets/waas_skill_reminder.mdx';
 
 This guide outlines the processes for canceling, speeding up, and dropping transactions. By mastering these techniques, you can ensure that your transactions are processed promptly and accurately. 
 
+## Paginate the transaction list
+
+The [List all transactions](/v2/api-references/transactions/list-all-transactions) operation returns results one page at a time. Pagination is controlled by two separate cursor parameters, `before` and `after`, which move the page window in opposite directions. The `direction` parameter is unrelated to paging and only controls sort order.
+
+- `after`: Pages forward to the next page. Pass the `after` value returned in the `pagination` object of the previous response.
+- `before`: Pages backward to the previous page. Pass the `before` value returned in the `pagination` object of the previous response.
+
+On your first request, do not include either `before` or `after`. Cobo returns the first page together with a `pagination` object that contains the `before` and `after` cursor values you use to navigate from it. Use the `limit` parameter to set the number of records per page.
+
+<Note>The `direction` parameter is a separate sort control and does not move the page window. It accepts `ASC` (ascending, the default) or `DESC` (descending), and only determines the order in which records are returned. Paging forward and backward is always controlled by `after` and `before`.</Note>
+
+### Pagination walkthrough
+
+1. Send the first request with no `before` and no `after` parameter. The response returns the first page and a `pagination` object containing `before`, `after`, and `total_count`.
+2. To move forward to the next page, send another request with `after` set to the `after` value from the previous response.
+3. To move backward to the previous page, send another request with `before` set to the `before` value from the previous response.
+4. When the response returns an empty `after` value, you have reached the end of the results. When the response returns an empty `before` value, you have reached the start of the results.
+
 ## Cancel a transaction
 
 Canceling a transaction stops it while it is still pending.

--- a/v2/guides/transactions/validate-addresses.mdx
+++ b/v2/guides/transactions/validate-addresses.mdx
@@ -1,0 +1,38 @@
+---
+title: "Validate addresses"
+lang: "en"
+description: "Validate transaction destination addresses server-side with the Cobo API instead of hand-coded, per-chain format rules."
+---
+
+import WaasSkillReminder from '/snippets/waas_skill_reminder.mdx';
+
+<WaasSkillReminder />
+
+Validating an address before you use it as a transaction destination helps you avoid failed transactions and funds sent to malformed addresses. The canonical way to validate an address is to call the Cobo API, which performs the check server-side for the specified chain. Do not rely on hand-coded, per-chain address-format rules in your own integration, because address formats differ by chain and change over time.
+
+## Validate a single address (WaaS 2.0)
+
+Use the [Check address validity](/v2/api-references/wallets/check-address-validity) operation (`GET /wallets/check_address_validity`). Pass two query parameters: `chain_id` (the chain to validate against) and `address` (the address to check). The response contains a single boolean field, `validity`: `true` means the address is valid for that chain, and `false` means it is not. The response is a boolean only and does not include a reason field.
+
+Worked example — validating an XRP address: pass `chain_id` set to `XRP` and `address` set to the address you want to check. Because validation is performed server-side per `chain_id`, the same address is judged against the rules of the chain you specify.
+
+## Validate multiple addresses (WaaS 2.0)
+
+Two batch operations are available:
+
+- [Check addresses validity](/v2/api-references/wallets/check-addresses-validity) (`GET /wallets/check_addresses_validity`): validates multiple addresses for a single chain in one request.
+- [Check address validity across chains](/v2/api-references/wallets/check-address-validity-across-chains) (`GET /wallets/check_address_chains_validity`): validates one address across multiple chains in one request.
+
+## Validate an address (WaaS 1.0)
+
+If you are still on WaaS 1.0, use the equivalent legacy operations:
+
+- [GET /v1/custody/is_valid_address/](/v1/api-references/custody-wallet/is_valid_address) for Custodial Wallets.
+- [GET /v1/custody/mpc/is_valid_address/](/v1/api-references/mpc-wallet/mpc_is_valid_address) for MPC Wallets.
+
+It is recommended to migrate to WaaS 2.0 and use Check address validity.
+
+## Related guides
+
+- [List all transactions](/v2/api-references/transactions/list-all-transactions)
+- [Check address validity](/v2/api-references/wallets/check-address-validity)

--- a/v2/guides/webhooks-callbacks/webhook-event-type.mdx
+++ b/v2/guides/webhooks-callbacks/webhook-event-type.mdx
@@ -252,6 +252,42 @@ For payment webhook events, please refer to [Order Status and Events](/v2/paymen
   </tbody>
 </table>
 
+### `ComplianceKytScreenings` event data
+
+The `compliance.kyt.screenings.status.updated` event carries a `ComplianceKytScreenings` payload (`KytScreeningsEventData`). This payload reports two independent status fields, `review_status` and `funds_status`. Track them separately: `review_status` reflects the screening and review progress of the case, and `funds_status` reflects the state of the associated funds.
+
+**`review_status` (`ReviewStatusType`)**
+
+| Value | Meaning |
+|-------|---------|
+| `PendingScreening` | The screening case has been created and is waiting for AML/KYT screening to run. |
+| `Screened` | AML/KYT screening has completed for the case. |
+| `PendingDecision` | Screening has completed and the case is awaiting a decision. |
+| `PendingReview` | The case requires manual review before a decision is reached. |
+| `Approved` | The case has been approved. |
+| `Rejected` | The case has been rejected. |
+| `Unsupported` | The case involves a chain or token that screening does not support. |
+| `Bypassed` | Screening was skipped for the case. |
+
+**`funds_status` (`FundsStatusType`)**
+
+| Value | Meaning |
+|-------|---------|
+| `Frozen` | The associated funds have been frozen. |
+| `Refunding` | A refund of the funds is in progress. |
+| `Refunded` | The funds have been refunded. |
+| `RefundFailed` | The refund attempt failed. |
+| `Unfreezing` | The funds are being unfrozen. |
+| `Unfrozen` | The funds have been unfrozen. |
+| `UnfreezingFailed` | The attempt to unfreeze the funds failed. |
+| `Isolating` | The funds are being isolated. |
+| `Isolated` | The funds have been isolated. |
+| `IsolationFailed` | The attempt to isolate the funds failed. |
+| `CoboDisposition` | The funds are being handled through a Cobo disposition. |
+| `Normal` | The funds are in a normal state with no compliance action applied. |
+
+The case decision that drives these status changes is represented by `KytScreeningsDecisionsType`, which has the values `Approval`, `ApprovalWithAlert`, `Rejection`, and `ManualReview`.
+
 ## Data structure of webhook events           
 For a complete introduction of the webhook event data and its data structure, refer to the [data](/v2/api-references/developers--webhooks/retrieve-event-information#response-data) property in the response of the Retrieve event information operation or the [data.data](/v2/api-references/developers--webhooks/list-all-webhook-events#response-data-data) property in the response of the List all webhook event operation. 
 

--- a/v2_cn/guides/transactions/manage-transactions.mdx
+++ b/v2_cn/guides/transactions/manage-transactions.mdx
@@ -10,6 +10,24 @@ import WaasSkillReminder from '/snippets/waas_skill_reminder_cn.mdx';
 
 本指南概述了取消、加速和放弃交易的过程。掌握这些技术可以确保您的交易得到及时准确的处理。
 
+## 对交易列表分页
+
+[List all transactions](/v2/api-references/transactions/list-all-transactions) 操作每次返回一页结果。分页由两个独立的游标参数 `before` 和 `after` 控制，它们分别向相反的方向移动分页窗口。`direction` 参数与分页无关，仅控制排序顺序。
+
+- `after`：向前翻到下一页。传入上一个响应的 `pagination` 对象中返回的 `after` 值。
+- `before`：向后翻到上一页。传入上一个响应的 `pagination` 对象中返回的 `before` 值。
+
+首次请求时，请勿包含 `before` 或 `after`。Cobo 会返回第一页，并附带一个 `pagination` 对象，其中包含用于翻页的 `before` 和 `after` 游标值。使用 `limit` 参数设置每页的记录数。
+
+<Note>`direction` 参数是独立的排序控制，不会移动分页窗口。它接受 `ASC`（升序，默认值）或 `DESC`（降序），仅决定记录返回的顺序。向前和向后翻页始终由 `after` 和 `before` 控制。</Note>
+
+### 分页操作步骤
+
+1. 发送首次请求，不带 `before` 和 `after` 参数。响应会返回第一页以及包含 `before`、`after` 和 `total_count` 的 `pagination` 对象。
+2. 要向前翻到下一页，请发送另一个请求，并将 `after` 设置为上一个响应中的 `after` 值。
+3. 要向后翻到上一页，请发送另一个请求，并将 `before` 设置为上一个响应中的 `before` 值。
+4. 当响应返回的 `after` 值为空时，表示您已到达结果的末尾。当响应返回的 `before` 值为空时，表示您已到达结果的开头。
+
 ## 取消交易
 
 取消交易是在交易仍处于待处理状态时停止它。

--- a/v2_cn/guides/transactions/validate-addresses.mdx
+++ b/v2_cn/guides/transactions/validate-addresses.mdx
@@ -1,0 +1,38 @@
+---
+title: "验证地址"
+lang: "zh-hans"
+description: "使用 Cobo API 在服务端验证交易目的地址，而非依赖手动编写的、按链区分的格式规则。"
+---
+
+import WaasSkillReminder from '/snippets/waas_skill_reminder_cn.mdx';
+
+<WaasSkillReminder />
+
+在将地址用作交易目的地址之前对其进行验证，有助于避免交易失败以及资金被发送到格式错误的地址。验证地址的规范方式是调用 Cobo API，由其针对指定的链在服务端执行检查。请勿在您自己的集成中依赖手动编写的、按链区分的地址格式规则，因为地址格式因链而异，并且会随时间变化。
+
+## 验证单个地址（WaaS 2.0）
+
+使用 [Check address validity](/v2/api-references/wallets/check-address-validity) 操作（`GET /wallets/check_address_validity`）。传入两个查询参数：`chain_id`（用于验证的链）和 `address`（待检查的地址）。响应包含一个布尔字段 `validity`：`true` 表示该地址对该链有效，`false` 表示无效。响应仅为布尔值，不包含原因字段。
+
+示例——验证 XRP 地址：将 `chain_id` 设置为 `XRP`，并将 `address` 设置为您要检查的地址。由于验证是按 `chain_id` 在服务端执行的，同一个地址会根据您指定的链的规则进行判断。
+
+## 验证多个地址（WaaS 2.0）
+
+提供两个批量操作：
+
+- [Check addresses validity](/v2/api-references/wallets/check-addresses-validity)（`GET /wallets/check_addresses_validity`）：在一次请求中验证单个链上的多个地址。
+- [Check address validity across chains](/v2/api-references/wallets/check-address-validity-across-chains)（`GET /wallets/check_address_chains_validity`）：在一次请求中验证一个地址在多个链上的有效性。
+
+## 验证地址（WaaS 1.0）
+
+如果您仍在使用 WaaS 1.0，请使用对应的旧版操作：
+
+- [GET /v1/custody/is_valid_address/](/v1/api-references/custody-wallet/is_valid_address) 适用于全托管钱包。
+- [GET /v1/custody/mpc/is_valid_address/](/v1/api-references/mpc-wallet/mpc_is_valid_address) 适用于 MPC 钱包。
+
+建议迁移到 WaaS 2.0 并使用 Check address validity。
+
+## 相关指南
+
+- [List all transactions](/v2/api-references/transactions/list-all-transactions)
+- [Check address validity](/v2/api-references/wallets/check-address-validity)

--- a/v2_cn/guides/webhooks-callbacks/webhook-event-type.mdx
+++ b/v2_cn/guides/webhooks-callbacks/webhook-event-type.mdx
@@ -254,6 +254,42 @@ import WaasSkillReminder from '/snippets/waas_skill_reminder_cn.mdx';
   </tbody>
 </table>
 
+### `ComplianceKytScreenings` 事件数据
+
+`compliance.kyt.screenings.status.updated` 事件携带 `ComplianceKytScreenings` 负载（`KytScreeningsEventData`）。该负载报告两个独立的状态字段 `review_status` 和 `funds_status`。请分别跟踪它们：`review_status` 反映案件的扫描与审核进度，`funds_status` 反映相关资金的状态。
+
+**`review_status`（`ReviewStatusType`）**
+
+| 值 | 含义 |
+|-------|---------|
+| `PendingScreening` | 扫描案件已创建，正在等待 AML/KYT 扫描运行。 |
+| `Screened` | 案件的 AML/KYT 扫描已完成。 |
+| `PendingDecision` | 扫描已完成，案件正在等待决策。 |
+| `PendingReview` | 案件在做出决策前需要人工审核。 |
+| `Approved` | 案件已批准。 |
+| `Rejected` | 案件已拒绝。 |
+| `Unsupported` | 案件涉及扫描不支持的链或代币。 |
+| `Bypassed` | 案件的扫描已被跳过。 |
+
+**`funds_status`（`FundsStatusType`）**
+
+| 值 | 含义 |
+|-------|---------|
+| `Frozen` | 相关资金已被冻结。 |
+| `Refunding` | 资金退款正在进行中。 |
+| `Refunded` | 资金已退款。 |
+| `RefundFailed` | 退款尝试失败。 |
+| `Unfreezing` | 资金正在解冻中。 |
+| `Unfrozen` | 资金已解冻。 |
+| `UnfreezingFailed` | 资金解冻尝试失败。 |
+| `Isolating` | 资金正在隔离中。 |
+| `Isolated` | 资金已隔离。 |
+| `IsolationFailed` | 资金隔离尝试失败。 |
+| `CoboDisposition` | 资金正在通过 Cobo 处置进行处理。 |
+| `Normal` | 资金处于正常状态，未应用任何合规操作。 |
+
+驱动这些状态变化的案件决策由 `KytScreeningsDecisionsType` 表示，其取值包括 `Approval`、`ApprovalWithAlert`、`Rejection` 和 `ManualReview`。
+
 ## Webhook 事件数据结构
 有关 webhook 事件数据和其数据结构的完整介绍，请参阅 Retrieve event information 操作的响应中的 [data](/v2/api-references/developers--webhooks/retrieve-event-information#response-data) 属性或 List all webhook events 操作的响应中的 [data.data](/v2/api-references/developers--webhooks/list-all-webhook-events#response-data-data) 属性。
 


### PR DESCRIPTION
## 关联来源

- https://pha.1cobo.com/T94244
- Aladdin 工单：1146733219888300039
- Aladdin 工单：1120163066025762855
- Aladdin 工单：1163384028240740805
- Aladdin 工单：1104732151631741057

## 意图

本次变更修复 Cobo Developer API 文档中发现的若干低严重度文档缺口，来源于 2025-11 至 2026-04 期间的 4 个支持工单（Phabricator T94244）。具体包括：List All Transactions 分页中 cursor 与 direction 的交互未说明、缺少地址校验（is_valid_address）指南、compliance.kyt.screenings.status.updated webhook 的状态枚举值（尤其 pending_decision）未文档化。每项均按工单证据补充对应文档。

## 变更摘要

- `docs.json`：在英文与中文导航中新增 `v2/guides/transactions/validate-addresses` 与 `v2_cn/guides/transactions/validate-addresses` 入口，使新增的地址校验指南可被访问。
- `v2/guides/transactions/manage-transactions.mdx`：补充 List All Transactions 分页说明，明确 cursor/direction（before/after）的配合用法，并说明结果末尾返回空字符串作为终止条件（依据 OpenAPI Pagination schema）。
- `v2_cn/guides/transactions/manage-transactions.mdx`：同步上述分页说明的中文版本，保持 EN/CN 一致。
- `v2/guides/transactions/validate-addresses.mdx`（新增）：新增地址校验指南，以 is_valid_address 作为推荐的规范校验方式，响应仅说明布尔字段 `validity`（依据 OpenAPI spec）。
- `v2_cn/guides/transactions/validate-addresses.mdx`（新增）：上述地址校验指南的中文版本。
- `v2/guides/webhooks-callbacks/webhook-event-type.mdx`：为 compliance.kyt.screenings.status.updated 事件补充 KYT 状态枚举表（ReviewStatusType / FundsStatusType / KytScreeningsDecisionsType），枚举值与 spec 逐字节对齐。
- `v2_cn/guides/webhooks-callbacks/webhook-event-type.mdx`：同步上述 KYT 状态枚举表的中文版本，枚举名保持英文未翻译。
- `v1/faqs/address-management.mdx`：在 v1 地址管理 FAQ 中新增指向地址校验指南的交叉链接（v1 仅英文）。

依据：
- Primary doc edits：以上 7 个文件，均已通过审校并对照 OpenAPI spec（只读）核实，EN/CN 一致，v1 正确保持仅英文。
- API spec edits：无
- API spec sync：无

## 待确认事项

- KYT review_status 线上大小写：spec 枚举为 `PendingDecision`，但工单中报告为 `pending_decision`。需在真实 payload 中确认实际线上字段大小写后方可视为权威。
- review_status / funds_status 的通俗含义说明：当前依据枚举值名保守撰写，建议由产品/合规团队复核后定稿。
- List All Transactions 渲染后的参考页是否按描述暴露 pagination.before / pagination.after 参数，需在生成的参考文档中确认。

说明（不属于本次改动、非阻塞项）：
- 工单 1104732151631741057（API playground Go 示例 request_id 与 wallet_id 相同）属于 playground 代码生成器逻辑问题，不在本文档仓库范围内，未在本 PR 处理。
- 与本次无关的既有 mintlify autosweep 导航告警（引用了不存在的 `v2/api-references/autosweep/cancel-auto-sweep-task-by-id`）及 v1 FAQ 中既有的 "returns an zero" 语法问题，均为既有问题，非本次变更引入，不作为阻塞项。
