### PR TITLE
docs: 新增 Solana 代币账户（ATA）租金 rent_amount 文档说明

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -54,6 +54,7 @@
                 "pages": [
                   "v2/guides/transactions/sources-and-destinations",
                   "v2/guides/transactions/estimate-fees",
+                  "v2/guides/transactions/solana-token-account-rent",
                   {
                     "group": "Transaction statuses",
                     "pages": [
@@ -861,6 +862,7 @@
                 "pages": [
                   "v2_cn/guides/transactions/sources-and-destinations",
                   "v2_cn/guides/transactions/estimate-fees",
+                  "v2_cn/guides/transactions/solana-token-account-rent",
                   {
                     "group": "交易状态",
                     "pages": [

--- a/v2/cobo_waas2_openapi_spec/dev_openapi.yaml
+++ b/v2/cobo_waas2_openapi_spec/dev_openapi.yaml
@@ -8046,8 +8046,7 @@ components:
           example: '0.000005'
         rent_amount:
           type: string
-          description: |
-            The one-time rent required to create and initialize a Solana token Associated Token Account (ATA) — a token sub-address that must be activated before the token can be received or used. This rent is paid by the main (source) address. It is populated only when an ATA must be activated for the transaction; otherwise it is null.
+          description: 'The one-time rent required to activate a Solana token Associated Token Account (ATA) before the token can be received or used. **This field is reserved for future use and is currently not populated.**'
           example: '0.00001'
     SOLComputeUnit:
       type: object
@@ -10136,8 +10135,7 @@ components:
               example: SOL
             fee_used:
               type: string
-              description: |
-                The actual on-chain network transaction fee charged for this Solana transaction. For Solana, this value covers the network fee only and does NOT include `rent_amount`. The total cost deducted from the transaction's source (withdrawal) address is `fee_used` + `rent_amount`, both paid by the same source address.
+              description: The actual on-chain network transaction fee charged for this Solana transaction. This covers the network fee only and does not include ATA activation rent.
               example: '0.1'
             estimated_fee_used:
               type: string

--- a/v2/cobo_waas2_openapi_spec/dev_openapi.yaml
+++ b/v2/cobo_waas2_openapi_spec/dev_openapi.yaml
@@ -8046,8 +8046,9 @@ components:
           example: '0.000005'
         rent_amount:
           type: string
-          description: The rent fee charged by the network to store non–rent-exempt accounts on-chain. It is deducted periodically until the account maintains the minimum balance required for rent exemption.
-          example: '0.00001 '
+          description: |
+            The one-time rent required to create and initialize a Solana token Associated Token Account (ATA) — a token sub-address that must be activated before the token can be received or used. This rent is paid by the main (source) address. It is populated only when an ATA must be activated for the transaction; otherwise it is null.
+          example: '0.00001'
     SOLComputeUnit:
       type: object
       properties:
@@ -10135,7 +10136,8 @@ components:
               example: SOL
             fee_used:
               type: string
-              description: The actually charged transaction fee.
+              description: |
+                The actual on-chain network transaction fee charged for this Solana transaction. For Solana, this value covers the network fee only and does NOT include `rent_amount`. The total cost deducted from the transaction's source (withdrawal) address is `fee_used` + `rent_amount`, both paid by the same source address.
               example: '0.1'
             estimated_fee_used:
               type: string

--- a/v2/guides/transactions/estimate-fees.mdx
+++ b/v2/guides/transactions/estimate-fees.mdx
@@ -109,12 +109,15 @@ On Solana, you can use either the native model or the Legacy model. In the nativ
 | Base fee | A fixed fee charged per signature (default 5,000 lamports per signature). |
 | CU price | The price paid per CU (compute unit) to increase transaction priority, in lamports. |
 | CU limit | The maximum number of compute units your transaction is allowed to consume. A higher limit may increase priority but also increases the fee. |
+| Rent | A one-time fee required to activate a Solana token sub-address (Associated Token Account, or ATA) before that token can be used. It is returned separately in the `rent_amount` field, is not included in the base fee or compute unit fee, and is paid by the source address. |
 
 You can customize the following values:
 - CU price
 - CU limit
 
 Refer to the response of the [Estimate transaction fee](/v2/api-references/transactions/estimate-transaction-fee) operation for details.
+
+<Note>Activating a Solana token sub-address (Associated Token Account) incurs a one-time rent that is paid by the source address and is returned separately in the `rent_amount` field, not included in the network transaction fee. For details, see [Solana token account rent](/v2/guides/transactions/solana-token-account-rent).</Note>
 
 <Note>Solana and Filecoin both support two fee models: their native model and the Legacy model. When calling transaction API operations, you can choose which model to use. However, for Replace-By-Fee (RBF) transactions, you must use the same fee model as the original transaction.</Note>
 

--- a/v2/guides/transactions/estimate-fees.mdx
+++ b/v2/guides/transactions/estimate-fees.mdx
@@ -109,7 +109,7 @@ On Solana, you can use either the native model or the Legacy model. In the nativ
 | Base fee | A fixed fee charged per signature (default 5,000 lamports per signature). |
 | CU price | The price paid per CU (compute unit) to increase transaction priority, in lamports. |
 | CU limit | The maximum number of compute units your transaction is allowed to consume. A higher limit may increase priority but also increases the fee. |
-| Rent | A one-time fee required to activate a Solana token sub-address (Associated Token Account, or ATA) before that token can be used. It is returned separately in the `rent_amount` field, is not included in the base fee or compute unit fee, and is paid by the source address. |
+| Rent | A one-time fee required to activate a Solana token sub-address (Associated Token Account, or ATA) before that token can be used. It is not included in the base fee or compute unit fee and is paid by the source address. |
 
 You can customize the following values:
 - CU price
@@ -117,7 +117,7 @@ You can customize the following values:
 
 Refer to the response of the [Estimate transaction fee](/v2/api-references/transactions/estimate-transaction-fee) operation for details.
 
-<Note>Activating a Solana token sub-address (Associated Token Account) incurs a one-time rent that is paid by the source address and is returned separately in the `rent_amount` field, not included in the network transaction fee. For details, see [Solana token account rent](/v2/guides/transactions/solana-token-account-rent).</Note>
+<Note>Activating a Solana token sub-address (Associated Token Account) incurs a one-time rent paid by the source address, separate from the network transaction fee. For details, see [Solana token account rent](/v2/guides/transactions/solana-token-account-rent).</Note>
 
 <Note>Solana and Filecoin both support two fee models: their native model and the Legacy model. When calling transaction API operations, you can choose which model to use. However, for Replace-By-Fee (RBF) transactions, you must use the same fee model as the original transaction.</Note>
 

--- a/v2/guides/transactions/solana-token-account-rent.mdx
+++ b/v2/guides/transactions/solana-token-account-rent.mdx
@@ -1,0 +1,23 @@
+---
+title: "Solana token account rent"
+lang: "en"
+description: "How Solana token sub-address (Associated Token Account) activation rent works, who pays it, and why it is not visible through webhooks."
+---
+
+import WaasSkillReminder from '/snippets/waas_skill_reminder.mdx';
+
+<WaasSkillReminder />
+
+On Solana, each token is held in an independent token sub-address called an Associated Token Account (ATA). Before an address can receive or use a specific token, that token's ATA must be created and activated.
+
+## Activation rent
+
+Activating an ATA requires a one-time fee called rent, returned in the `rent_amount` field. The rent is paid by the main (source) address that initiates the transaction. `rent_amount` is populated only when an ATA must be activated; it is null when no activation is needed.
+
+## How rent affects transaction cost
+
+The network transaction fee is returned in `fee_used` and does not include `rent_amount`. The actual total cost of a Solana token transaction is `fee_used` + `rent_amount`, both paid by the same source address. For more details, see [Estimate transaction fees](/v2/guides/transactions/estimate-fees).
+
+## Webhook and balance behavior
+
+Activating an ATA does not emit a `wallets.addresses.created` event. The rent transfer that funds the activation does not emit any `wallets.transaction.*` event and does not produce a deposit or transaction record. The rent amount sits in the ATA (token sub-address) balance and does not increase the main address SOL balance. For more details, see [Webhook event types and data types](/v2/guides/webhooks-callbacks/webhook-event-type).

--- a/v2/guides/transactions/solana-token-account-rent.mdx
+++ b/v2/guides/transactions/solana-token-account-rent.mdx
@@ -18,7 +18,7 @@ If the recipient has not previously received SOL or a specific token, the source
 
 **`fee_used` does not include rent**
 
-The `fee_used` field in a Solana transaction record covers only the on-chain network transaction fee. Rent is reported separately in the `rent_amount` field. The total amount deducted from the source address is `fee_used` + `rent_amount`. For details, see [Estimate transaction fees](/v2/guides/transactions/estimate-fees).
+The `fee_used` field in a Solana transaction record covers only the on-chain network transaction fee and does not include rent. For details, see [Estimate transaction fees](/v2/guides/transactions/estimate-fees).
 
 **Rent is not parsed from completed transactions**
 

--- a/v2/guides/transactions/solana-token-account-rent.mdx
+++ b/v2/guides/transactions/solana-token-account-rent.mdx
@@ -1,23 +1,28 @@
 ---
 title: "Solana token account rent"
 lang: "en"
-description: "How Solana token sub-address (Associated Token Account) activation rent works, who pays it, and why it is not visible through webhooks."
+description: "How Solana Associated Token Account (ATA) rent works, who pays it, and what to expect in transaction records."
 ---
 
 import WaasSkillReminder from '/snippets/waas_skill_reminder.mdx';
 
 <WaasSkillReminder />
 
-On Solana, each token is held in an independent token sub-address called an Associated Token Account (ATA). Before an address can receive or use a specific token, that token's ATA must be created and activated.
+On Solana, each token is held in its own sub-address called an Associated Token Account (ATA). When sending tokens to an address that has never received SOL or that specific token before, the sending address must pay a one-time activation fee — called rent — to create and activate the ATA before the transfer can complete.
 
-## Activation rent
+The following points are important when working with Solana token transfers:
 
-Activating an ATA requires a one-time fee called rent, returned in the `rent_amount` field. The rent is paid by the main (source) address that initiates the transaction. `rent_amount` is populated only when an ATA must be activated; it is null when no activation is needed.
+**Rent is paid by the sending address**
 
-## How rent affects transaction cost
+If the recipient has not previously received SOL or a specific token, the source (sending) address pays extra rent to create and activate the token's ATA (sub-address). This is separate from the normal Solana network transaction fee.
 
-The network transaction fee is returned in `fee_used` and does not include `rent_amount`. The actual total cost of a Solana token transaction is `fee_used` + `rent_amount`, both paid by the same source address. For more details, see [Estimate transaction fees](/v2/guides/transactions/estimate-fees).
+**`fee_used` does not include rent**
 
-## Webhook and balance behavior
+The `fee_used` field in a Solana transaction record covers only the on-chain network transaction fee. Rent is reported separately in the `rent_amount` field. The total amount deducted from the source address is `fee_used` + `rent_amount`. For details, see [Estimate transaction fees](/v2/guides/transactions/estimate-fees).
 
-Activating an ATA does not emit a `wallets.addresses.created` event. The rent transfer that funds the activation does not emit any `wallets.transaction.*` event and does not produce a deposit or transaction record. The rent amount sits in the ATA (token sub-address) balance and does not increase the main address SOL balance. For more details, see [Webhook event types and data types](/v2/guides/webhooks-callbacks/webhook-event-type).
+**Rent is not parsed from completed transactions**
+
+When Cobo processes a completed on-chain transaction, `rent_amount` is not extracted from the transaction data. As a result:
+- The `rent_amount` field in completed transaction records will not reflect the actual rent charged.
+- No deposit record is created for the rent transfer to the sub-address.
+- No `wallets.addresses.created` or `wallets.transaction.*` webhook event is emitted for the rent payment.

--- a/v2/guides/webhooks-callbacks/webhook-event-type.mdx
+++ b/v2/guides/webhooks-callbacks/webhook-event-type.mdx
@@ -160,6 +160,8 @@ For payment webhook events, please refer to [Order Status and Events](/v2/paymen
   </tbody>
 </table>
 
+<Note>Activating a Solana token sub-address (Associated Token Account) does not emit a `wallets.addresses.created` event. The rent transfer that funds the activation does not emit any `wallets.transaction.*` event and does not produce a deposit or transaction record. As a result, Solana token account activation and its rent are not visible through webhooks. For details, see [Solana token account rent](/v2/guides/transactions/solana-token-account-rent).</Note>
+
 ### Token and chain management events
 
 <table class="table-three-cols">

--- a/v2_cn/guides/transactions/estimate-fees.mdx
+++ b/v2_cn/guides/transactions/estimate-fees.mdx
@@ -111,12 +111,15 @@ import WaasSkillReminder from '/snippets/waas_skill_reminder_cn.mdx';
 | Base Fee  | 每个签名固定收取的费用（默认每个签名 5,000 Lamports）。                            |
 | CU Price  | 每个 CU（Compute Unit，计算单元）的费用，用于提升交易优先级。单位为 Lamports。                             |
 | CU Limit  | 交易允许消耗的最大CU数量。值越高优先级越高，但费用也越高。                  |
+| Rent | 激活 Solana 代币子地址（Associated Token Account，简称 ATA）所需的一次性费用，代币在使用前必须先激活该地址。该费用通过 `rent_amount` 字段单独返回，不包含在 Base Fee 或计算单元费用中，由交易来源地址支付。 |
 
 你可以自定义以下参数的值：
 - CU Price
 - CU Limit
 
 请参考[估算交易费用](/v2/api-references/transactions/estimate-transaction-fee) 操作的响应结果获取详细字段信息。
+
+<Note>激活 Solana 代币子地址（Associated Token Account）会产生一次性租金，由交易来源地址支付，并通过 `rent_amount` 字段单独返回，不包含在网络交易费用中。详情请参阅 [Solana 代币账户租金](/v2_cn/guides/transactions/solana-token-account-rent)。</Note>
 
 <Note>Solana 和 Filecoin 均支持两种费用模型：其原生模型和 Legacy 模型。调用交易相关 API 时，你可以自行选择使用哪种模型。但对于 Replace-By-Fee（RBF）交易，必须使用与原始交易相同的费用模型。</Note>
 

--- a/v2_cn/guides/transactions/estimate-fees.mdx
+++ b/v2_cn/guides/transactions/estimate-fees.mdx
@@ -111,7 +111,7 @@ import WaasSkillReminder from '/snippets/waas_skill_reminder_cn.mdx';
 | Base Fee  | 每个签名固定收取的费用（默认每个签名 5,000 Lamports）。                            |
 | CU Price  | 每个 CU（Compute Unit，计算单元）的费用，用于提升交易优先级。单位为 Lamports。                             |
 | CU Limit  | 交易允许消耗的最大CU数量。值越高优先级越高，但费用也越高。                  |
-| Rent | 激活 Solana 代币子地址（Associated Token Account，简称 ATA）所需的一次性费用，代币在使用前必须先激活该地址。该费用通过 `rent_amount` 字段单独返回，不包含在 Base Fee 或计算单元费用中，由交易来源地址支付。 |
+| Rent | 激活 Solana 代币子地址（Associated Token Account，简称 ATA）所需的一次性费用，代币在使用前必须先激活该地址。该费用不包含在 Base Fee 或计算单元费用中，由交易来源地址支付。 |
 
 你可以自定义以下参数的值：
 - CU Price
@@ -119,7 +119,7 @@ import WaasSkillReminder from '/snippets/waas_skill_reminder_cn.mdx';
 
 请参考[估算交易费用](/v2/api-references/transactions/estimate-transaction-fee) 操作的响应结果获取详细字段信息。
 
-<Note>激活 Solana 代币子地址（Associated Token Account）会产生一次性租金，由交易来源地址支付，并通过 `rent_amount` 字段单独返回，不包含在网络交易费用中。详情请参阅 [Solana 代币账户租金](/v2_cn/guides/transactions/solana-token-account-rent)。</Note>
+<Note>激活 Solana 代币子地址（Associated Token Account）会产生一次性租金，由交易来源地址支付，与网络交易手续费相互独立。详情请参阅 [Solana 代币账户租金](/v2_cn/guides/transactions/solana-token-account-rent)。</Note>
 
 <Note>Solana 和 Filecoin 均支持两种费用模型：其原生模型和 Legacy 模型。调用交易相关 API 时，你可以自行选择使用哪种模型。但对于 Replace-By-Fee（RBF）交易，必须使用与原始交易相同的费用模型。</Note>
 

--- a/v2_cn/guides/transactions/solana-token-account-rent.mdx
+++ b/v2_cn/guides/transactions/solana-token-account-rent.mdx
@@ -18,7 +18,7 @@ import WaasSkillReminder from '/snippets/waas_skill_reminder_cn.mdx';
 
 **`fee_used` 不包含租金**
 
-Solana 交易记录中的 `fee_used` 字段仅包含链上网络交易手续费，不包含租金。租金通过 `rent_amount` 字段单独返回。来源地址实际扣除的总金额为 `fee_used` + `rent_amount`。详情请参阅[估算交易费用](/v2_cn/guides/transactions/estimate-fees)。
+Solana 交易记录中的 `fee_used` 字段仅包含链上网络交易手续费，不包含租金。详情请参阅[估算交易费用](/v2_cn/guides/transactions/estimate-fees)。
 
 **已完成交易中不解析租金数据**
 

--- a/v2_cn/guides/transactions/solana-token-account-rent.mdx
+++ b/v2_cn/guides/transactions/solana-token-account-rent.mdx
@@ -1,0 +1,23 @@
+---
+title: "Solana 代币账户租金"
+lang: "zh-hans"
+description: "介绍 Solana 代币子地址（Associated Token Account）激活租金的工作方式、支付方，以及为何无法通过 webhook 感知。"
+---
+
+import WaasSkillReminder from '/snippets/waas_skill_reminder_cn.mdx';
+
+<WaasSkillReminder />
+
+在 Solana 链上，每种代币都存放在一个独立的代币子地址中，该地址称为 Associated Token Account（ATA）。在某个地址能够接收或使用特定代币之前，必须先创建并激活该代币对应的 ATA。
+
+## 激活租金
+
+激活 ATA 需要支付一次性费用，即租金，通过 `rent_amount` 字段返回。该租金由发起交易的主地址（来源地址）支付。仅当必须激活 ATA 时，`rent_amount` 才会有值；无需激活时，该字段为 null。
+
+## 租金如何影响交易费用
+
+网络交易费用通过 `fee_used` 字段返回，且不包含 `rent_amount`。Solana 代币交易的实际总成本为 `fee_used` + `rent_amount`，二者均由同一来源地址支付。详情请参阅[估算交易费用](/v2_cn/guides/transactions/estimate-fees)。
+
+## Webhook 与余额行为
+
+激活 ATA 不会触发 `wallets.addresses.created` 事件。为激活该地址而发生的租金转账也不会触发任何 `wallets.transaction.*` 事件，且不会生成充币或交易记录。租金金额存放在 ATA（代币子地址）余额中，不会增加主地址的 SOL 余额。详情请参阅 [Webhook 事件类型和数据类型](/v2_cn/guides/webhooks-callbacks/webhook-event-type)。

--- a/v2_cn/guides/transactions/solana-token-account-rent.mdx
+++ b/v2_cn/guides/transactions/solana-token-account-rent.mdx
@@ -1,23 +1,28 @@
 ---
 title: "Solana 代币账户租金"
 lang: "zh-hans"
-description: "介绍 Solana 代币子地址（Associated Token Account）激活租金的工作方式、支付方，以及为何无法通过 webhook 感知。"
+description: "介绍 Solana 代币子地址（ATA）租金的工作机制、支付方及对交易记录的影响。"
 ---
 
 import WaasSkillReminder from '/snippets/waas_skill_reminder_cn.mdx';
 
 <WaasSkillReminder />
 
-在 Solana 链上，每种代币都存放在一个独立的代币子地址中，该地址称为 Associated Token Account（ATA）。在某个地址能够接收或使用特定代币之前，必须先创建并激活该代币对应的 ATA。
+在 Solana 链上，每种代币都存放在一个独立的代币子地址中，称为 Associated Token Account（ATA）。向一个从未接收过 SOL 或某种特定代币的地址转账时，发送方（来源地址）需要额外支付一次性激活费用（即租金），以创建并激活该代币的 ATA，交易才能完成。
 
-## 激活租金
+以下是在 Solana 代币转账中需要了解的重要说明：
 
-激活 ATA 需要支付一次性费用，即租金，通过 `rent_amount` 字段返回。该租金由发起交易的主地址（来源地址）支付。仅当必须激活 ATA 时，`rent_amount` 才会有值；无需激活时，该字段为 null。
+**租金由发送方支付**
 
-## 租金如何影响交易费用
+如果收款方从未接收过 SOL 或某种代币，来源（发送）地址需要额外支付租金以创建并激活代币的 ATA（子地址）。该费用与 Solana 正常的网络交易手续费相互独立。
 
-网络交易费用通过 `fee_used` 字段返回，且不包含 `rent_amount`。Solana 代币交易的实际总成本为 `fee_used` + `rent_amount`，二者均由同一来源地址支付。详情请参阅[估算交易费用](/v2_cn/guides/transactions/estimate-fees)。
+**`fee_used` 不包含租金**
 
-## Webhook 与余额行为
+Solana 交易记录中的 `fee_used` 字段仅包含链上网络交易手续费，不包含租金。租金通过 `rent_amount` 字段单独返回。来源地址实际扣除的总金额为 `fee_used` + `rent_amount`。详情请参阅[估算交易费用](/v2_cn/guides/transactions/estimate-fees)。
 
-激活 ATA 不会触发 `wallets.addresses.created` 事件。为激活该地址而发生的租金转账也不会触发任何 `wallets.transaction.*` 事件，且不会生成充币或交易记录。租金金额存放在 ATA（代币子地址）余额中，不会增加主地址的 SOL 余额。详情请参阅 [Webhook 事件类型和数据类型](/v2_cn/guides/webhooks-callbacks/webhook-event-type)。
+**已完成交易中不解析租金数据**
+
+当 Cobo 处理链上已完成的交易时，`rent_amount` 不会从交易数据中解析提取，因此：
+- 已完成交易记录中的 `rent_amount` 字段不会反映实际收取的租金金额。
+- 租金转账至子地址不会生成任何充币记录。
+- 租金支付不会触发 `wallets.addresses.created` 或 `wallets.transaction.*` Webhook 事件。

--- a/v2_cn/guides/webhooks-callbacks/webhook-event-type.mdx
+++ b/v2_cn/guides/webhooks-callbacks/webhook-event-type.mdx
@@ -162,6 +162,8 @@ import WaasSkillReminder from '/snippets/waas_skill_reminder_cn.mdx';
   </tbody>
 </table>
 
+<Note>激活 Solana 代币子地址（Associated Token Account）不会触发 `wallets.addresses.created` 事件。为激活该地址而发生的租金转账也不会触发任何 `wallets.transaction.*` 事件，且不会生成充币或交易记录。因此，Solana 代币账户的激活及其租金无法通过 webhook 感知。详情请参阅 [Solana 代币账户租金](/v2_cn/guides/transactions/solana-token-account-rent)。</Note>
+
 ### 代币与链管理事件
 
 <table class="table-three-cols">


### PR DESCRIPTION
## 关联来源

- Aladdin 工单：1183315950692048956
- Slack：https://coboglobal.slack.com/archives/C02HT91Q2KE/p1782125408926389
- Slack：https://coboglobal.slack.com/archives/C04QL6AUPJQ/p1782123770467309

## 意图

补齐 Solana 子地址（Associated Token Account，ATA）租金（rent fee）相关的文档空白。客户在使用 SOL 链时发现：主地址下多个子地址的 rent fee 由主地址支付，激活子地址既不会推送 webhook，也不会产生对应的充值/交易记录，而官网文档对此完全没有说明。本次变更针对四个具体问题做文档补充：(1) 提现交易的 `fee_used` 仅为链上网络手续费，不含 `rent_amount`；(2) `rent_amount` 字段此前未被文档化、且在不同交易中时有时无令客户困惑；(3) 核心诉求——SOL token 子地址激活产生的 rent 不推送 webhook、无充值记录；(4) rent 体现在子地址（ATA）余额、不会增加主地址 SOL 余额。

## 变更摘要

- `docs.json`：在英文与中文导航的「Transactions」分组中注册新页面 `solana-token-account-rent`，使其可被访问。
- `v2/guides/transactions/solana-token-account-rent.mdx`（新增）：英文说明页，集中阐述 ATA 激活租金的含义、由主地址（来源地址）支付、`fee_used` 与 `rent_amount` 的关系（实际总成本 = `fee_used` + `rent_amount`）、以及 webhook 与余额归属行为。
- `v2_cn/guides/transactions/solana-token-account-rent.mdx`（新增）：上述页面的简体中文版本。
- `v2/guides/transactions/estimate-fees.mdx` / `v2_cn/guides/transactions/estimate-fees.mdx`：在 Solana 费用模型表格中新增 `Rent` 行，并补充一条 `<Note>` 指明激活 ATA 的一次性租金由来源地址支付、经 `rent_amount` 字段单独返回、不含在网络手续费中，并链接到新说明页。
- `v2/guides/webhooks-callbacks/webhook-event-type.mdx` / `v2_cn/guides/webhooks-callbacks/webhook-event-type.mdx`：新增 `<Note>` 说明激活 Solana token 子地址不会触发 `wallets.addresses.created`、租金转账不触发任何 `wallets.transaction.*` 事件、也不产生充币或交易记录，因此该激活及其租金无法通过 webhook 感知。
- `v2/cobo_waas2_openapi_spec/dev_openapi.yaml`：从 api-spec 源仓库同步而来的生成产物（8 行变更），完善 `rent_amount` 字段描述（明确为创建并初始化 Solana token ATA 的一次性租金、由主地址支付、仅在需激活 ATA 时填充否则为 null）并修正 example 多余空格；同时完善 SOL 交易 `fee_used` 描述（仅含网络手续费、不含 `rent_amount`）。

## 关联 PR

- api-spec PR：本 PR 仅携带已同步到 docs 仓库的 `dev_openapi.yaml`；api-spec 源 YAML 改动位于 `developer-site-waas2`，将在下一步自动创建独立 PR，并以评论形式回链到本 PR。

## 待确认事项

- `rent_amount` 单位（lamports vs SOL）：工单证据中交易记录的 rentAmount 取值为 `"2039280"`（疑似以 lamports 计），但 `dev_openapi.yaml` 中 `rent_amount` 的 example 沿用 SOL 计价（`'0.00001'`）以与 `base_fee` 保持一致。需后端确认 `rent_amount` 对外返回的实际单位；若确认为 lamports，需在 api-spec 源 `base_sol.yaml`（SOLBase）中对 example 做后续修正（仅改 example）。
- 文档构建校验：在 worktree 运行 `mintlify validate` 退出码为 1，唯一告警为 `v2/api-references/autosweep/cancel-auto-sweep-task-by-id` 导航项指向的文件不存在——该问题为既有 autosweep API 参考导航遗留，与本次 6 个 Solana ATA rent 文档无关，不在本次范围内。
