### PR TITLE
docs: 明确 Cobo Auth Nonce 取值

### DIFF
--- a/v2/guides/overview/cobo-auth.mdx
+++ b/v2/guides/overview/cobo-auth.mdx
@@ -23,7 +23,7 @@ headers = {
 ```
 
 - Biz-Api-Key: The API key used for the request. For more details, refer to [API key](#api-key).
-- Biz-Api-Nonce: A random string used as the request nonce.
+- Biz-Api-Nonce: The nonce value for this request. Cobo signing helpers set this to the current Unix timestamp in milliseconds (for example, `1718587017026`). This value must exactly match the `NONCE` component in `str_to_sign`. For details, refer to [Nonce](#nonce).
 - Biz-Api-Signature: The API signature. To learn how to calculate an API signature, see [Calculate an API Signature](#calculate-the-api-signature).
 
 If you are using Cobo's WaaS SDKs, you only need to provide your API secret because the SDKs handles the remaining steps for you.
@@ -137,7 +137,21 @@ The Development and Production environments use **separate Cobo Portals with sep
 
 ## Nonce
 
-In WaaS 2.0 authentication, Nonce refers to the value of the `Biz-Api-Nonce` request header. This can be any random string.
+In WaaS 2.0 authentication, Nonce refers to the value of the `Biz-Api-Nonce` request header. Cobo signing helpers generate it automatically as the current Unix timestamp in milliseconds, such as `1718587017026`.
+
+The value in the `Biz-Api-Nonce` request header must exactly match the `NONCE` component in `str_to_sign`. For example, the following pair is valid because both places use the same millisecond timestamp:
+
+```text
+Biz-Api-Nonce: 1718587017026
+str_to_sign = GET|/v2/transactions/transfer|1718587017026|chain_id=ETH&limit=10|
+```
+
+The following pair is invalid because the request header and `str_to_sign` use different nonce values:
+
+```text
+Biz-Api-Nonce: 1718587017026
+str_to_sign = GET|/v2/transactions/transfer|1718587017027|chain_id=ETH&limit=10|
+```
 
 ## Calculate the API signature
 

--- a/v2_cn/guides/overview/cobo-auth.mdx
+++ b/v2_cn/guides/overview/cobo-auth.mdx
@@ -13,7 +13,7 @@ import WaasSkillReminder from '/snippets/waas_skill_reminder_cn.mdx';
 
 为确保您加密资产的安全访问，WaaS 服务要求您使用 EdDSA 签名对每个 API 请求进行签名（可公开访问的 API 操作除外）。
 
-您需要在请求头中提供 API Key、`Biz-Api-Nonce`（随机字符串）和 API 签名：
+您需要在请求头中提供 API Key、`Biz-Api-Nonce`（Nonce）和 API 签名：
 
 ```
 headers = {
@@ -24,7 +24,7 @@ headers = {
 ```
 
 - Biz-Api-Key：用于请求的 API Key。更多详情，请参阅 [API Key](#api-key)。
-- Biz-Api-Nonce：用作请求 nonce 的随机字符串。
+- Biz-Api-Nonce：本次请求的 Nonce 值。Cobo 签名辅助工具会将其设置为当前 Unix 毫秒时间戳，例如 `1718587017026`。该值必须与 `str_to_sign` 中的 `NONCE` 组件完全相同。更多详情，请参阅 [Nonce](#nonce)。
 - Biz-Api-Signature：API 签名。要了解如何计算 API 签名，请参阅[计算 API 签名](#calculate-the-api-signature)。
 
 如果您使用 Cobo 的 WaaS SDK，您只需提供 API Key，因为 SDK 会为您处理其余步骤。
@@ -139,7 +139,21 @@ Public Key (Hex):
 
 ## Nonce
 
-在 WaaS 2.0 身份验证中，Nonce 指请求头 `Biz-Api-Nonce` 的值，可以是任意随机字符串。
+在 WaaS 2.0 身份验证中，Nonce 指请求头 `Biz-Api-Nonce` 的值。Cobo 签名辅助工具会自动将其生成为当前 Unix 毫秒时间戳，例如 `1718587017026`。
+
+请求头 `Biz-Api-Nonce` 的值必须与 `str_to_sign` 中的 `NONCE` 组件完全相同。例如，以下配对有效，因为两个位置使用了相同的毫秒时间戳：
+
+```text
+Biz-Api-Nonce: 1718587017026
+str_to_sign = GET|/v2/transactions/transfer|1718587017026|chain_id=ETH&limit=10|
+```
+
+以下配对无效，因为请求头和 `str_to_sign` 使用了不同的 Nonce 值：
+
+```text
+Biz-Api-Nonce: 1718587017026
+str_to_sign = GET|/v2/transactions/transfer|1718587017027|chain_id=ETH&limit=10|
+```
 
 <a name="calculate-the-api-signature"></a>
 ## 计算 API 签名


### PR DESCRIPTION
## 意图

本次变更来自对 `/developers/v2_cn/guides/overview/cobo-auth` 中 `NONCE` 含义的反馈：现有表述让读者无法判断 `Biz-Api-Nonce` 到底是任意随机字符串，还是当前 Unix 毫秒时间戳。文档需要明确 Cobo Auth 签名流程中 `Biz-Api-Nonce` 与 `str_to_sign` 里的 `NONCE` 组件如何对应，并避免写入代码证据未能支撑的公开 replay/time-window 规则。

## 变更摘要

- `v2_cn/guides/overview/cobo-auth.mdx`：将 `Biz-Api-Nonce` 从“随机字符串”改为 Nonce，并说明 Cobo 签名辅助工具使用当前 Unix 毫秒时间戳，且请求头值必须与 `str_to_sign` 中的 `NONCE` 完全一致；补充有效和无效示例，减少中文读者对取值格式的歧义。
- `v2/guides/overview/cobo-auth.mdx`：同步英文 Cobo Auth 指南中的 Nonce 说明和匹配/不匹配示例，保持中英文文档规则一致。

## 代码证据

- `waas2/developers/api_key_sign_helper.py:57`：SDK/helper 通过 `now_ms()` 生成 nonce 值，证明文档中的客户端生成策略是当前 Unix 毫秒时间戳。
- `waas2/developers/api_key_sign_helper.py:87`：SDK/helper 将生成的时间戳作为 nonce 组件参与签名。
- `waas2/developers/api_key_sign_helper.py:98`：SDK/helper 将同一个生成的时间戳字符串发送到 `Biz-Api-Nonce` 请求头。
- `waas2/authentications/universal_access_control/authentications/api_key_authentication.py:47`：Public WaaS2 auth 从请求头读取 `biz-api-nonce`。
- `waas2/authentications/universal_access_control/authentications/api_key_authentication.py:51`：Public WaaS2 auth 使用 method、path、nonce、params、body 构造签名原文。
- `waas2/authentications/universal_access_control/authentications/api_key_authentication.py:63`：Public WaaS2 auth 校验包含 nonce 请求头值的 Ed25519 签名。
- `cobo-libs/cobo_libs/api/restful/authentications/signature.py:84`：Shared EdDSA authentication 将 `biz-api-nonce` 作为字符串从请求头读取。
- `cobo-libs/cobo_libs/api/restful/authentications/signature.py:88`：Shared EdDSA verifier 使用 method、path、nonce、query params、body 构造签名原文。
- `cobo-libs/cobo_libs/api/restful/authentications/signature.py:97`：Shared EdDSA verifier 校验该签名原文上的签名。
- `cobo-libs/cobo_libs/api/restful/utils/api_key_sign_helper.py:63`：Shared signing helper 通过 `now_ms()` 生成 nonce 值。
- `cobo-libs/cobo_libs/api/restful/utils/api_key_sign_helper.py:102`：Shared signing helper 将生成的时间戳作为 `Biz-Api-Nonce` 发送。
- `custody/api/base_internal_api.py:56`：Legacy internal API 将 `CUS_NONCE` 解析为整数，说明这是另一条内部 nonce 路径。
- `custody/api/base_internal_api.py:62`：Legacy internal API 对 `CUS_NONCE` 执行毫秒时间窗口校验，因此本 PR 未将该内部路径的 time-window 规则写入公开 Cobo Auth 文档。

## ⚠️ 待确认事项

无
