### PR TITLE
docs: 补充批量转账风控前提条件说明

### DIFF
--- a/v2/guides/transactions/batch-transfer.mdx
+++ b/v2/guides/transactions/batch-transfer.mdx
@@ -31,6 +31,12 @@ The address of the batch transfer smart contract is [`0x3d963e23a9229D2ACd25E9FF
 - You have basic knowledge of interacting with smart contracts, including preparing `calldata`, locating contract methods, and using the `approve` method on a token contract to authorize the batch transfer contract to spend tokens.  
 - The batch transfer feature currently only supports transactions initiated from MPC Wallets and Custodial Wallets (Web3 Wallets).
 
+## Risk control prerequisites
+
+Batch transfers submitted through the [Call smart contract](/v2/api-references/transactions/call-smart-contract) API are contract-call transactions. Like any contract-call transaction, they are evaluated against your organization's on-chain Transaction Policies in Cobo Portal, specifically the Contract Call Policy type. Before you submit batch transfer requests, configure a Contract Call Policy that permits calls to the batch transfer contract address (`0x3d963e23a9229D2ACd25E9FFC358be1a35460ecc`) on the relevant chain for the source wallet. See [Risk controls](https://manuals.cobo.com/en/portal/risk-controls/introduction) for how to configure Transaction Policies in Cobo Portal. If no Contract Call Policy permits this contract address for the source wallet, the transaction can be rejected.
+
+Cobo Portal risk controls treat contract-call transactions and token-transfer transactions as distinct, independently configurable policy types: Contract Call Policy and Token Transfer Policy. Because this guide's batch transfers go through [Call smart contract](/v2/api-references/transactions/call-smart-contract), they are governed by Contract Call Policy, a separate configuration from the Token Transfer Policy that governs ordinary transfers submitted through [Transfer token](/v2/api-references/transactions/transfer-token). Configuring one policy type does not configure the other.
+
 ## Batch transfer of ETH
 The following steps apply to batch transfers of ETH (native coin) on the supported chains:
 
@@ -88,6 +94,7 @@ The following steps apply to batch transfers of ERC-20 tokens on the supported c
 - Number of recipients exceeds the limit.  
 - Mismatch between the `value` in the API request and the amounts in the `calldata` (for ETH transfers).  
 - Insufficient gas limit.
+- The batch transfer contract address is not covered by a Contract Call Policy configured for the source wallet, causing the transaction to be rejected with the `RejectedTransactionPolicy` status. See [Transaction status](/v2/guides/transactions/status) for the full status table.
 
 
 ## Example script for generating `calldata`

--- a/v2_cn/guides/transactions/batch-transfer.mdx
+++ b/v2_cn/guides/transactions/batch-transfer.mdx
@@ -32,6 +32,12 @@ import WaasSkillReminder from '/snippets/waas_skill_reminder_cn.mdx';
 - 具备调用链上智能合约的基础知识，包括准备 `calldata`、查找合约方法，以及在 Token 合约中找到并调用 `approve` 方法以授权批量转账合约代扣代币。
 - 当前批量转账功能仅支持使用 MPC 钱包和全托管钱包（Web3 钱包）发起交易。
 
+## 风控前提条件
+
+批量转账通过 [Call smart contract](/v2/api-references/transactions/call-smart-contract) 接口提交，属于合约交互类型的交易。与其他合约交互交易一样，此类交易会依据您所在团队在 Cobo Portal 中配置的链上交易风控策略（Transaction Policies）进行评估，具体对应 Contract Call Policy 这一策略类型。在提交批量转账请求前，请为来源钱包配置一条 Contract Call Policy，允许在相应链上调用批量转账合约地址（`0x3d963e23a9229D2ACd25E9FFC358be1a35460ecc`）。有关如何在 Cobo Portal 中配置交易风控策略，请参考[风控策略](https://manuals.cobo.com/en/portal/risk-controls/introduction)。如果没有 Contract Call Policy 允许来源钱包调用该合约地址，交易可能会被拒绝。
+
+Cobo Portal 的风控策略将合约交互交易和代币转账交易视为两种独立、可分别配置的策略类型：Contract Call Policy 与 Token Transfer Policy。由于本指南中的批量转账通过 [Call smart contract](/v2/api-references/transactions/call-smart-contract) 发起，因此由 Contract Call Policy 管控，这与管控普通转账（通过 [Transfer token](/v2/api-references/transactions/transfer-token) 发起）的 Token Transfer Policy 是各自独立的配置，配置其中一种策略并不会自动配置另一种。
+
 ## 批量转 ETH
 以下步骤适用于在支持的链上批量转账 ETH（原生币）的场景：
 
@@ -88,6 +94,7 @@ import WaasSkillReminder from '/snippets/waas_skill_reminder_cn.mdx';
 - 收款地址数量超过限制。  
 - `value` 与 `calldata` 中金额不一致（针对 ETH 转账）。  
 - Gas 预估不足。  
+- 批量转账合约地址未被来源钱包所配置的 Contract Call Policy 覆盖，导致交易被拒绝，返回 `RejectedTransactionPolicy` 状态。参考[交易状态](/v2_cn/guides/transactions/status)查看完整状态表。
 
 
 ## 生成 `calldata` 示例脚本


### PR DESCRIPTION
## 关联来源

- https://pha.1cobo.com/T95921
- https://pha.1cobo.com/T95885
- https://pha.1cobo.com/T95438
- Slack：https://coboglobal.slack.com/archives/C09BZ9SJSHK/p1781579452404929

## 意图

T95921 — Bulk Send 风控策略配置文档缺口（父任务 T95885，Goal T95438：开发者体验优化 H1 2026）。事故起因：客户（org 2536）两笔 ETH 批量转账交易被 `deny:tx:policy` 拒绝，卡在 processing/pending，根因是批量转账在 EVM 链上通过智能合约调用实现，会触发 Contract Call Policy 风控策略，客户未配置该策略导致交易被拒，而文档此前完全没有说明这一前置配置要求。本次改动为 `v2/guides/transactions/batch-transfer.mdx`（及其中文版）新增风控前提条件说明，并补充 Contract Call Policy 与 Token Transfer Policy 的区别说明，避免客户混淆两类策略。

## 变更摘要

- `v2/guides/transactions/batch-transfer.mdx`：在 Prerequisites 与 Batch transfer of ETH 之间新增 "Risk control prerequisites" 章节，说明批量转账通过 Call smart contract 接口提交、受 Contract Call Policy 管控，需为来源钱包配置允许调用批量转账合约地址（`0x3d963e23a9229D2ACd25E9FFC358be1a35460ecc`）的策略；并说明 Contract Call Policy 与 Token Transfer Policy 是独立配置的策略类型。同时在 Common failure causes 列表中新增一条：合约地址未被 Contract Call Policy 覆盖会导致 `RejectedTransactionPolicy` 拒绝，并链接到交易状态页。
- `v2_cn/guides/transactions/batch-transfer.mdx`：中文版镜像改动，新增"风控前提条件"章节及常见失败原因条目，内容与英文版对应；策略类型标识符（Contract Call Policy、Token Transfer Policy、RejectedTransactionPolicy、Call smart contract、Transfer token）保留英文原文，未翻译。

未涉及 OpenAPI、导航或 changelog 文件的改动。

需要在其他仓库改动：Payments 实际的 Bulk Send 功能（`custody/waas2/payment/` 的 `BulkSendManager`；OpenAPI 路径 `/payments/bulk_sends`）目前在 developer-site 仓库中没有任何 prose 集成指南，该功能的风控前提说明应落地于 `payments-manual` 仓库（不在本次改动范围内，本 worktree 中也不存在该仓库）。此外，Cobo Portal 风控策略配置文档中反向指向 Bulk Send 场景的交叉引用，应落地于 `product-manual` 仓库（同样不在本 worktree 范围内）。

## 代码证据

- `custody/waas2/risk/enums/onchain_policy.py:31-34` — `OnchainPolicyConditionType` 枚举定义 TokenTransfer（`ContractTokenTransfers`）与 ContractCall（`ContractCall`）为两种独立的链上策略条件类型，支撑文档中"两类策略独立配置"的表述。
- `custody/custody/custody/data/enums.py:2965` — `RC_DENY_TRANSACTION_POLICY = "deny:tx:policy"` 确认 Slack 事故中引用的拒绝原因码在代码中存在。
- `custody-2.0-website/src/pages/RiskControl/Policies/CreatePolicy/index.tsx:106,150-151` — Portal 风控策略创建页面中 `RiskPolicyType.ContractCall` 作为独立策略类型存在。
- `custody-2.0-website/src/pages/RiskControl/Policies/RevisionsDetail/index.tsx:113` — `RiskPolicyType.Transfer`（代币转账）作为与 ContractCall 分开的策略类型存在。
- `custody-2.0-website/src/locales/en-US/app.ts:92-93` — Portal 前端暴露独立的可见标签 "Transfer Policy" 与 "Contract Call Policy"，支撑文档中两个策略名称的表述。
- `v2/guides/transactions/status.mdx:143,247-248`（及 CN 对应行）— 确认 `RejectedTransactionPolicy` 状态与风控介绍链接 `https://manuals.cobo.com/en/portal/risk-controls/introduction` 已在本仓库其他页面使用，本次改动复用同一 URL 与状态标识符。
- `v2/guides/transactions/batch-transfer.mdx:28-32,85-90`（及 CN 对应行）— 确认改动位置（Prerequisites 章节结尾、Common failure causes 列表）与本次插入点一致。

## ⚠️ 待确认事项

- **待人工确认**：Contract Call Policy 未配置时是否确为"默认拒绝"（default reject）这一具体行为分支，仅确认了 `deny:tx:policy` 拒绝原因码本身存在（`custody/custody/custody/data/enums.py:2965`），未能在本 worktree 中找到并核实风控引擎具体的默认拒绝分支逻辑（该证据来自上游计划对 `custody/` 仓库的引用，本 worktree 中该仓库不存在，无法独立复核）。文档措辞已采用"可能被拒绝"的条件性表述，未断言绝对默认行为，但建议风控/后端同学复核该分支的真实默认行为。
- **待人工确认**：Contract Call Policy 与 Token Transfer Policy 的适用范围区分（按链、按交易类型的精确边界，尤其是 TRON 链 Bulk Send 走 token transfer 策略而非 contract call 策略的判定逻辑）依据的是 `custody-2.0-website` 仓库的前端代码引用，同样因该仓库在本 worktree 中不存在而无法独立复核。本次文档改动已刻意避免在 `v2/guides/transactions/batch-transfer.mdx` 中提及 TRON、Bulk Send 或普通 payout，以免跨产品表述失真，但建议风控/Payments 同学复核该区分的准确性。
- 已确认无需修改：Payments 的 Bulk Send prose 指南缺口与 Portal 风控文档的反向交叉引用均属于不同仓库（`payments-manual` / `product-manual`）范围，已在"变更摘要"中列出，非本 PR 阻塞项。
