### PR TITLE
docs: 同步 Fee Station 相关的 OpenAPI bundle

### DIFF
--- a/v2/cobo_waas2_openapi_spec/dev_openapi.yaml
+++ b/v2/cobo_waas2_openapi_spec/dev_openapi.yaml
@@ -3508,7 +3508,7 @@ paths:
       operationId: estimate_fee_station_fee
       summary: Estimate transaction fee
       description: |
-        <Note>This operation is **deprecated**. Please use the enhanced version [Check Fee Station usage](https://www.cobo.com/developers/v2/api-references/feestation/check-fee-station-usage) instead.</Note> 
+        <Note>This operation is **deprecated** and retained only for backward compatibility. Use [Check Fee Station usage](https://www.cobo.com/developers/v2/api-references/feestation/check-fee-station-usage) for all new integrations.</Note>
 
         This operation estimates the transaction fee of a token transfer based on the fee model that the chain uses, considering factors such as network congestion and transaction complexity.
 
@@ -10382,7 +10382,7 @@ components:
         - DisableAutoFuel
       example: PassiveAutoFuel
       description: |
-        The mode of transaction fee payment using Fee Station. Currently, Fee Station supports transactions made with MPC Wallets on EVM-compatible chains, TRON, and Solana.
+        The mode of transaction fee payment using Fee Station. Currently, Fee Station supports eligible transactions made with MPC Wallets and Web3 Wallets on EVM-compatible chains, TRON, and Solana.
         For more details, refer to [Fee Station](https://manuals.cobo.com/en/portal/fee-station/introduction).
 
         - `ProActiveAutoFuel`: Always use Fee Station to pay transaction fees.  
@@ -10392,7 +10392,7 @@ components:
 
         If this parameter is **not specified**, it defaults to the behavior of `UsePortalPreference`.
 
-        **Note**: TRON and Solana does not support `PassiveAutoFuel` due to its fee delegation mechanism.
+        **Note**: TRON and Solana do not support `PassiveAutoFuel` due to their fee delegation mechanisms.
     SkipCheckType:
       type: string
       enum:
@@ -10570,7 +10570,7 @@ components:
       description: |
         The transaction category defined by Cobo. Possible values include: 
           - `AutoSweep`: An auto-sweep transaction.
-          - `AutoFueling`: A transaction where Fee Station pays transaction fees to an address within your MPC Wallets.
+          - `AutoFueling`: A transaction where Fee Station automatically pays transaction fees for eligible MPC Wallet and Web3 Wallet transactions.
           - `AutoFuelingRefund`: A refund for an auto-fueling transaction.
           - `SafeTxMessage`: A message signing transaction initiated by an MPC wallet to authorize a Smart Contract Wallet (Safe\{Wallet\}) transaction.
           - `BillPayment`: A transaction to pay Cobo bills through Fee Station.


### PR DESCRIPTION
## 关联来源

- Spec 源改动：CoboGlobal/developer-site-waas2#2357
- 配套文档改动：CoboGlobal/product-manual#765
- Workmate playbook run `run_4c57f4fcccbe4088`

## 意图

`dev_openapi.yaml` 在 developer-site-waas2 中撰写与评审，同步到本仓库后才会在线上 Developer Hub 生效。本 PR 即该同步步骤。

## 变更摘要

单文件、**+4 / -4**，逐字来自 developer-site-waas2 分支 `playbook/run-run_4c57f4fcccbe4088-api-spec` 的 bundle：

1. `auto_fuel` 模式说明 —— 由「supports transactions made with MPC Wallets」改为「supports eligible transactions made with MPC Wallets and Web3 Wallets」。Fee Station 实际同时支持两类钱包，此前 spec 描述过时。
2. `AutoFueling` 枚举值说明 —— 由「pays transaction fees to an address within your MPC Wallets」改为「automatically pays transaction fees for eligible MPC Wallet and Web3 Wallet transactions」。
3. `estimate_fee_station_fee` 弃用说明 —— 加强为「deprecated and retained only for backward compatibility. Use Check Fee Station usage for all new integrations.」保留弃用标记与迁移指引，未删除该操作。
4. `PassiveAutoFuel` 说明的主谓一致修正（`does`→`do`、`its`→`their`、`mechanism`→`mechanisms`），属既有语法问题。

## 验证

- 同步前，本仓库的 `dev_openapi.yaml` 与 developer-site-waas2 master 版**逐字相同**（28742 行，0 差异），确认本文件是该 spec 源的镜像，整体覆盖是安全操作。
- 同步后 diff 恰为上述 4 行，与 #2357 的四处修正一一对应，无夹带改动。

## 说明：本次同步为何是手工完成

doc-writing-core 的 `spec_syncer` 步骤本应自动完成该同步，其目标路径按 product 选择，custody 对应本仓库的 `v2/cobo_waas2_openapi_spec/dev_openapi.yaml`。但本次运行传入的 `repo_path` 是 product-manual，本仓库未参与该运行，该步骤按设计检测到目标不存在后返回 `succeeded: false` 并停止（未误建文件）。属输入设置问题，非 playbook 缺陷。

## ⚠️ 待确认事项

- **「eligible」未枚举具体条件**：描述以「eligible ... transactions」涵盖钱包类型与链的组合限制，未列出不支持的组合。若需明确枚举，请指出。
- **`PassiveAutoFuel` 的链限制未重新核实**：本次仅修正该句语法，未验证「TRON 与 Solana 因手续费代付机制不支持该模式」这一结论当前是否仍成立。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
