### PR TITLE
docs: 同步 merchant_kyc 相关的 OpenAPI bundle

### DIFF
--- a/v2/cobo_waas2_openapi_spec/dev_openapi.yaml
+++ b/v2/cobo_waas2_openapi_spec/dev_openapi.yaml
@@ -17357,10 +17357,11 @@ components:
       properties:
         file_id:
           type: string
+          format: uuid
           description: |
-            The AWS file link of the uploaded file, which you can retrieve by calling
+            The file ID of the uploaded file, which you can retrieve by calling
             [Upload file](https://www.cobo.com/developers/v2/api-references/payment/upload-file).
-          example: 'https://example-bucket.s3.us-east-1.amazonaws.com/uploads/business_registration.pdf'
+          example: f47ac10b-58cc-4372-a567-0e02b2c3d479
         file_type:
           $ref: '#/components/schemas/MerchantKycCompanyAttachmentFileType'
     MerchantKycPersonAttachment:
@@ -17438,21 +17439,21 @@ components:
           maxLength: 64
           description: |
             The date of birth of the individual, usually in the format YYYYMMDD.
-          example: '19900101'
+          example: '20290322'
         issue_date:
           type: string
           maxLength: 64
           description: |
             The issue date refers to the date when a document, such as an identification card or passport,
             was officially issued or granted, usually in the format YYYYMMDD.
-          example: '20180101'
+          example: '20290322'
         expiration_date:
           type: string
           maxLength: 64
           description: |
             The expiration date refers to the date when a document, such as an identification card or passport,
             is no longer valid or legally usable, usually in the format YYYYMMDD.
-          example: '20280101'
+          example: '20290322'
         attachments:
           type: array
           description: |
@@ -17506,15 +17507,15 @@ components:
         establish_date:
           type: string
           description: The establishment date of the company.
-          example: '2020-01-01'
+          example: '20290322'
         commencement_date:
           type: string
           description: The commencement date of the company.
-          example: '2020-01-01'
+          example: '20290322'
         valid_period:
           type: string
           description: The valid period of the company registration.
-          example: '2020-01-01'
+          example: '20290322'
         register_address:
           $ref: '#/components/schemas/MerchantKycAddress'
         legal_info:


### PR DESCRIPTION
## 关联来源

- component 源文件：CoboGlobal/developer-site-waas2#2361
- bundle：CoboGlobal/developer-site-waas2#2365

## 意图

`dev_openapi.yaml` 在 developer-site-waas2 中撰写与评审，同步到本仓库后才会在线上 Developer Hub 生效。本 PR 即该同步步骤。

## 变更摘要

单文件、**+9 / -8**，逐字取自 developer-site-waas2 master（`f146b3fb`，即 #2365 合并后）的 bundle：

- `MerchantKycCompanyAttachment.file_id` —— 描述由「The AWS file link of the uploaded file」改为「The file ID of the uploaded file」，示例由 S3 链接改为 uuid，并补 `format: uuid`。
- `MerchantKycPersonInfo` —— 三处日期示例（`19900101`、`20180101`、`20280101`）统一为 `20290322`。
- `MerchantKycCompanyInfo` —— 三处日期示例（`2020-01-01` ×3）统一为 `20290322`。

## 验证

- 同步前，本仓库的 `dev_openapi.yaml` 与 developer-site-waas2 master **在 #2365 合并前逐字相同**（28742 行，0 差异），确认本文件是该 spec 源的镜像，整体覆盖是安全操作。
- 同步后 diff 恰为上述 9 处，与 #2365 的改动一一对应，无夹带。
- `yaml.safe_load` 解析通过。

## 说明

本仓库的 bundle 与上游是手工同步的（上游没有生成脚本，`build_scripts/copy_openapi_to_payments.sh` 也只是原样 `cp`）。#2361 当时只改了 component 源文件、未同步 bundle，因此改动一度无法分发到本仓库；#2365 补齐后才具备同步条件。

另注：与 Fee Station 相关的 bundle 改动仍在 developer-site-waas2#2357（未合入 master），其同步由本仓库 #391 单独处理，与本 PR 不重叠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
