### PR TITLE
docs: 同步 dev_openapi.yaml —— AutoFuelType 补上 Tempo 链

### DIFF
--- a/v2/cobo_waas2_openapi_spec/dev_openapi.yaml
+++ b/v2/cobo_waas2_openapi_spec/dev_openapi.yaml
@@ -10382,7 +10382,7 @@ components:
         - DisableAutoFuel
       example: PassiveAutoFuel
       description: |
-        The mode of transaction fee payment using Fee Station. Currently, Fee Station supports eligible transactions made with MPC Wallets and Web3 Wallets on EVM-compatible chains, TRON, and Solana.
+        The mode of transaction fee payment using Fee Station. Currently, Fee Station supports eligible transactions made with MPC Wallets and Web3 Wallets on EVM-compatible chains, TRON, Solana, and Tempo.
         For more details, refer to [Fee Station](https://manuals.cobo.com/en/portal/fee-station/introduction).
 
         - `ProActiveAutoFuel`: Always use Fee Station to pay transaction fees.  


### PR DESCRIPTION
## 背景

从 `developer-site-waas2` 同步 `dev_openapi.yaml`。上游改动:CoboGlobal/developer-site-waas2#2395

起因是做 [T98349](https://pha.1cobo.com/T98349)(Fee Station / TRON Gas 指引与实际产品路径不一致)时核对 `AutoFuelType` 的适用范围,发现漏了 Tempo。

## 改动

仅一行 —— `AutoFuelType` 的 description:

> Currently, Fee Station supports eligible transactions made with MPC Wallets and Web3 Wallets on EVM-compatible chains, TRON, ~~and Solana~~ **Solana, and Tempo**.

## 同步范围核对

本仓库的 `dev_openapi.yaml` 是 waas2 的副本。同步前两边在各自 `master` 上**逐字一致**(28743 行,`diff` 0 处差异),所以本次是一个干净的单行同步,没有夹带其他漂移。同步后已再次 `diff` 确认与 waas2 分支上的版本完全一致,并用 yaml 解析校验可正常 parse。

## 依据

- `custody-2.0-website` `src/pages/Organization/FeeStation/GasToken/ManagePage/index.tsx:122` —— `gasFuelStrategies` 中存在 `chainIDentify === 'TEMPO'`,与同一处的 `TRON`(114 行)、`SOL`(118 行)同构
- `product-manual` `en/portal/fee-station/introduction.mdx` 的支持链表已列出 Tempo:**美元稳定币付 gas ✅ / gas token 付 gas ❌**

即 Tempo 确实在 Fee Station 代付范围内,只是仅支持稳定币这一条路径。这句只补链名,路径差异由 product-manual 的支持链表承载。

## 合并顺序

建议**与 waas2#2395 一起合**,或在其之后合。两边内容已对齐,单独合本 PR 会让本仓库短暂领先 spec 源。
